### PR TITLE
Switch to yas_llama.cpp

### DIFF
--- a/Makefile.sync
+++ b/Makefile.sync
@@ -1,6 +1,6 @@
-UPSTREAM=https://github.com/ggerganov/llama.cpp.git
+UPSTREAM=https://github.com/YASSERRMD/yas_llama.cpp.git
 WORKDIR=llama/vendor
-FETCH_HEAD=de4c07f93783a1a96456a44dc16b9db538ee1618
+FETCH_HEAD=9689cf2084d29f0d7b48547a0958860d572dc119
 
 .PHONY: help
 help:

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Supported backends
 
-- [llama.cpp](https://github.com/ggerganov/llama.cpp) project founded by Georgi Gerganov.
+- [yas_llama.cpp](https://github.com/YASSERRMD/yas_llama.cpp), a fork of llama.cpp maintained by Mohamed Yasser.
 
 ### Observability
 - [Opik](https://www.comet.com/docs/opik/cookbook/ollama) is an open-source platform to debug, evaluate, and monitor your LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards. Opik supports native intergration to Ollama.

--- a/llama/README.md
+++ b/llama/README.md
@@ -1,12 +1,12 @@
 # `llama`
 
-This package provides Go bindings to [llama.cpp](https://github.com/ggerganov/llama.cpp).
+This package provides Go bindings to [yas_llama.cpp](https://github.com/YASSERRMD/yas_llama.cpp), a fork of llama.cpp.
 
 ## Vendoring
 
-Ollama vendors [llama.cpp](https://github.com/ggerganov/llama.cpp/) and [ggml](https://github.com/ggerganov/llama.cpp/tree/master/ggml/src). While we generally strive to contribute changes back upstream to avoid drift, we carry a small set of patches which are applied to the tracking commit.
+Ollama vendors [yas_llama.cpp](https://github.com/YASSERRMD/yas_llama.cpp) and [ggml](https://github.com/ggerganov/llama.cpp/tree/master/ggml/src). While we generally strive to contribute changes back upstream to avoid drift, we carry a small set of patches which are applied to the tracking commit.
 
-If you update the vendoring code, start by running the following command to establish the tracking llama.cpp repo in the `./vendor/` directory.
+If you update the vendoring code, start by running the following command to establish the tracking yas_llama.cpp repo in the `./vendor/` directory.
 
 ```shell
 make -f Makefile.sync apply-patches


### PR DESCRIPTION
## Summary
- use yas_llama.cpp as the upstream
- mention new backend in docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870e20393e88328b7ed9e2e5c147368